### PR TITLE
Enable and document service installation on Windows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,8 @@ sc start DrayTekWatcherService
 sc delete DrayTekWatcherService
 ```
 
+Once installed you can use the `Event Viewer` to check logs, or `service.msc` to control the service (like changing the startup type to `Automatic`).
+
 ## License
 
 This software is released under the [BSD-Clause 2 license](https://opensource.org/licenses/BSD-2-Clause). 

--- a/readme.md
+++ b/readme.md
@@ -95,17 +95,17 @@ dotnet build
 
 Currently, only systemd services are supported by [dotnet-releaser](https://github.com/xoofx/dotnet-releaser) for deb and rpm packages. But the tool is working as well as a windows service. Here is how to use the Windows `sc` (Service Control) to register the executable as a service.
 
-```batch
-# create (copy your toml configuration along with the draytek-watcher.exe file)
+```
+:: create (copy your toml configuration along with the draytek-watcher.exe file)
 sc create DrayTekWatcherService DisplayName="DrayTek-Watcher Service" binPath="full\path\to\\draytek-watcher.exe"
 
-# start
+:: start
 sc start DrayTekWatcherService
 
-# stop
+:: stop
 sc stop DrayTekWatcherService
 
-# delete
+:: delete
 sc delete DrayTekWatcherService
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,19 @@
 # draytek-watcher  [![Build Status](https://github.com/xoofx/draytek-watcher/workflows/ci/badge.svg?branch=main)](https://github.com/xoofx/draytek-watcher/actions)
 
-This a small daemon to install on an Linux/Ubuntu box to check the status of the WAN connection of a Draytek router and to reenable it if it seems to be down.
+This a small daemon to install on an Linux/Ubuntu/Windows box to check the status of the WAN connection of a Draytek router and to reenable it if it seems to be down.
 
 > **DISCLAIMER**
 >
 > I will provide no support for this project. I'm using it personally to reboot my WAN connection when it is stuck in a dangling state.
 >
-> This project is only tested with a [Draytek Vigor 2927ax](https://www.draytek.com/products/vigor2927/) and a Ubuntu server, might not work with a different version without some tweaking.
+> This project is only tested with:
+> - a [Draytek Vigor 2927ax](https://www.draytek.com/products/vigor2927/) and a Ubuntu server (systemd).
+> - a [Draytek Vigor 2927](https://www.draytek.com/products/vigor2927/) and a Windows 10 workstation (service).
 >
+> So it might not work with a different version without some tweaking.
 > It is using the telnet protocol to interact with the router.
 
-## Build and Install
+## Build and Install (for Linux)
 
 Clone this repo and install [.NET SDK 6.0+](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
 
@@ -18,7 +21,7 @@ Clone this repo and install [.NET SDK 6.0+](https://dotnet.microsoft.com/en-us/d
 Then install [dotnet-releaser](https://github.com/xoofx/dotnet-releaser):
 
 ```
-dotnet tool install --global dotnet-releaser"
+dotnet tool install --global dotnet-releaser
 ```
 
 Edit the configuration file in `draytek-watcher/draytek-watcher.toml` to update the admin password:
@@ -78,6 +81,32 @@ Jan 18 08:42:18 ak1-linux draytek-watcher[21335]: draytek-watcher[0] => WAN1 - W
 Jan 18 08:42:20 ak1-linux draytek-watcher[21335]: draytek-watcher[0] => WAN1 - Starting WAN.
 Jan 18 08:42:21 ak1-linux draytek-watcher[21335]: draytek-watcher[0] => WAN1 - Waiting to restart for 10s.
 Jan 18 08:42:31 ak1-linux draytek-watcher[21335]: draytek-watcher[0] => WAN1 - Restarted successfully.
+```
+
+## Build and Install (for Windows)
+
+Clone this repo and install [.NET SDK 6.0+](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
+
+Then run:
+
+```
+dotnet build
+```
+
+Currently, only systemd services are supported by [dotnet-releaser](https://github.com/xoofx/dotnet-releaser) for deb and rpm packages. But the tool is working as well as a windows service. Here is how to use the Windows `sc` (Service Control) to register the executable as a service.
+
+```batch
+# create (copy your toml configuration along with the draytek-watcher.exe file)
+sc create DrayTekWatcherService DisplayName="DrayTek-Watcher Service" binPath="full\path\to\\draytek-watcher.exe"
+
+# start
+sc start DrayTekWatcherService
+
+# stop
+sc start DrayTekWatcherService
+
+# delete
+sc delete DrayTekWatcherService
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ Currently, only systemd services are supported by [dotnet-releaser](https://gith
 
 ```
 :: create (copy your toml configuration along with the draytek-watcher.exe file)
-sc create DrayTekWatcherService DisplayName="DrayTek-Watcher Service" binPath="full\path\to\\draytek-watcher.exe"
+sc create DrayTekWatcherService DisplayName="DrayTek-Watcher Service" binPath="full\path\to\draytek-watcher.exe"
 
 :: start
 sc start DrayTekWatcherService

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ sc create DrayTekWatcherService DisplayName="DrayTek-Watcher Service" binPath="f
 sc start DrayTekWatcherService
 
 # stop
-sc start DrayTekWatcherService
+sc stop DrayTekWatcherService
 
 # delete
 sc delete DrayTekWatcherService

--- a/src/DrayTekWatcher/RouterConfiguration.cs
+++ b/src/DrayTekWatcher/RouterConfiguration.cs
@@ -96,9 +96,9 @@ public class RouterConfiguration
         configuration = null;
         if (filePath == null)
         {
-	        var entryAssembly = Assembly.GetEntryAssembly();
-	        var assemblyPath = Path.GetDirectoryName(entryAssembly!.Location);
-	        filePath = Path.Combine(assemblyPath!, $"{entryAssembly.GetName().Name}.toml");
+            var entryAssembly = Assembly.GetEntryAssembly();
+            var assemblyPath = Path.GetDirectoryName(entryAssembly!.Location);
+            filePath = Path.Combine(assemblyPath!, $"{entryAssembly.GetName().Name}.toml");
 
             logger.LogWarning($"Missing configuration file. Defaulting to {filePath}");
         }

--- a/src/DrayTekWatcher/RouterConfiguration.cs
+++ b/src/DrayTekWatcher/RouterConfiguration.cs
@@ -100,7 +100,7 @@ public class RouterConfiguration
             var assemblyPath = Path.GetDirectoryName(entryAssembly!.Location);
             filePath = Path.Combine(assemblyPath!, $"{entryAssembly.GetName().Name}.toml");
 
-            logger.LogWarning($"Missing configuration file. Defaulting to {filePath}");
+            logger.LogWarning($"Missing configuration file. Defaulting to {filePath}.");
         }
 
         if (!File.Exists(filePath))

--- a/src/DrayTekWatcher/RouterConfiguration.cs
+++ b/src/DrayTekWatcher/RouterConfiguration.cs
@@ -5,6 +5,7 @@
 namespace DrayTekWatcher.Core;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Tomlyn;
 using Tomlyn.Model;
@@ -95,8 +96,11 @@ public class RouterConfiguration
         configuration = null;
         if (filePath == null)
         {
-            logger.LogError("Missing configuration file.");
-            return false;
+	        var entryAssembly = Assembly.GetEntryAssembly();
+	        var assemblyPath = Path.GetDirectoryName(entryAssembly!.Location);
+	        filePath = Path.Combine(assemblyPath!, $"{entryAssembly.GetName().Name}.toml");
+
+            logger.LogWarning($"Missing configuration file. Defaulting to {filePath}");
         }
 
         if (!File.Exists(filePath))


### PR DESCRIPTION
Added documentation to build and install as a Windows service.

To be double-checked but I think Windows services disallow to pass arbitrary parameters (they have to be prefixed with a slash), So update a bit the code to use a default config file name when nothing is found in `args` (for simplicity).